### PR TITLE
Make GenerateJaxb2Classes Cacheable

### DIFF
--- a/src/main/groovy/com/gradleup/jaxb/tasks/GenerateJaxb2Classes.groovy
+++ b/src/main/groovy/com/gradleup/jaxb/tasks/GenerateJaxb2Classes.groovy
@@ -1,9 +1,20 @@
 package com.gradleup.jaxb.tasks
 
-
 import com.gradleup.jaxb.Jaxb2Plugin
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.logging.Logger
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 
 import static org.gradle.api.logging.Logging.getLogger
@@ -18,8 +29,41 @@ import static org.gradle.api.logging.Logging.getLogger
  * @author holgerstolzenberg
  * @since 1.0.0
  */
-class GenerateJaxb2Classes extends DefaultTask {
+@CacheableTask
+abstract class GenerateJaxb2Classes extends DefaultTask {
   private static final Logger LOG = getLogger(GenerateJaxb2Classes.class)
+
+  @InputFile
+  @PathSensitive(PathSensitivity.RELATIVE)
+  abstract RegularFileProperty getSchemaFile()
+
+  @Input
+  abstract Property<String> getBasePackage()
+
+  @Input
+  abstract Property<String> getEncoding()
+
+  @Input
+  abstract Property<Boolean> getExtension()
+
+  @Input
+  abstract Property<String> getAdditionalArgs()
+
+  @InputFile
+  @Optional
+  @PathSensitive(PathSensitivity.RELATIVE)
+  abstract RegularFileProperty getCatalogFile()
+
+  @InputFiles
+  @Optional
+  @PathSensitive(PathSensitivity.RELATIVE)
+  abstract ConfigurableFileCollection getBindingsFiles()
+
+  @Input
+  abstract Property<Boolean> getHeader()
+
+  @OutputDirectory
+  abstract DirectoryProperty getGeneratedSourcesDirectory()
 
   GenerateJaxb2Classes() {
     this.group = Jaxb2Plugin.TASK_GROUP
@@ -33,64 +77,36 @@ class GenerateJaxb2Classes extends DefaultTask {
         classname: project.extensions.jaxb2.taskName,
         classpath: project.configurations.jaxb2.asPath)
 
-    Set<XjcTaskConfig> xjcConfigs = project.extensions.jaxb2.xjc
+    // Transform package to directory location to specify depends/produces when multiple schema output to same generatedSourcesDir
+    // Changing one schema will only cause recompilation/generation of that schema
+    def generatedSourcesDirPackage = new File(generatedSourcesDirectory.get().asFile,
+            basePackage.get().replace(".", "/"))
 
-    for (XjcTaskConfig theConfig : xjcConfigs) {
-      def generatedSourcesDirParent = project.file(theConfig.generatedSourcesDir)
-      def basePackage = theConfig.basePackage
-      def encoding = theConfig.encoding
+    def arguments = [
+            destdir  : generatedSourcesDirectory.get().asFile,
+            package  : basePackage.get(),
+            schema   : schemaFile.get().asFile,
+            encoding : encoding.get(),
+            extension: extension.get(),
+            header   : header.get(),
+    ]
 
-      // Transform package to directory location to specify depends/produces when multiple schema output to same generatedSourcesDir
-      // Changing one schema will only cause recompilation/generation of that schema
-      def generatedSourcesDirPackage = new File(generatedSourcesDirParent,
-          basePackage.replace(".", "/"))
-
-      def schemaFile = project.file(theConfig.schema)
-      def catalogFile = (theConfig.catalog != null) ? project.file(theConfig.catalog) : null
-      def bindingsDir = theConfig.bindingsDir
-      def includedBindingFiles = bindingFileIncludes(theConfig)
-      def extension = theConfig.extension
-      def additionalArgs = theConfig.additionalArgs
-
-      def arguments = [
-        destdir: generatedSourcesDirParent,
-        package: basePackage,
-        schema: schemaFile,
-        encoding: encoding,
-        extension: extension,
-        header: theConfig.header,
-      ]
-
-      if (catalogFile) {
-        arguments.catalog = catalogFile
-      }
-
-      // the depends and produces is compared using the time-stamp of the schema file and the destination package folder
-      ant.xjc(arguments) {
-        depends(file: schemaFile)
-        produces(dir: generatedSourcesDirPackage, includes: "**/*.java")
-        arg(line: additionalArgs)
-
-        if (catalogFile) {
-          depends(file: catalogFile)
-        }
-
-        if (bindingsDir?.trim()) {
-          binding(dir: project.file(bindingsDir), includes: includedBindingFiles)
-        }
-      }
-    }
-  }
-
-  private static String bindingFileIncludes(XjcTaskConfig config) {
-    def files = config.includedBindingFiles
-
-    if (!files?.trim()) {
-      LOG.info("No binding file includes defined, falling back to '**/*.xjb' pattern.")
-      files = '**/*.xjb'
+    if (catalogFile.isPresent()) {
+      arguments.catalog = catalogFile.get().asFile
     }
 
-    LOG.info("Binding files: {}", files)
-    return files
+    // the depends and produces is compared using the time-stamp of the schema file and the destination package folder
+    ant.xjc(arguments) {
+      depends(file: schemaFile.get().asFile)
+      produces(dir: generatedSourcesDirPackage, includes: "**/*.java")
+      arg(line: additionalArgs.get())
+
+      if (catalogFile.isPresent()) {
+        depends(file: catalogFile.get().asFile)
+      }
+      bindingsFiles.each {
+        binding(file: it.path)
+      }
+    }
   }
 }


### PR DESCRIPTION
List of major updates/decisions:
1. Marked `GenerateJaxb2Classes` as a `@CacheableTask`
2. All inputs and outputs of `GenerateJaxb2Classes` are now properly tracked
3. For cacheability, each `XjcTaskConfig` results in the creation of a corresponding `GenerateJaxb2Classes` task. Each of these `GenerateJaxb2Classes` tasks writes to a unique output directory in the build directory to avoid overlapping outputs. A `Copy` task is also registered that will copy each of the `GenerateJaxb2Classes` outputs to its final destination, defined by `XjcTaskConfig.generatedSourcesDir`.
4. Updated `GenerateJaxb2Classes` to use Gradle managed properties
5. `XjcTaskConfig` was not updated to maintain compatibility with existing build configuration. 
